### PR TITLE
[cfid-598] Made Yaml servlet initializer more generic (no UAA refs)

### DIFF
--- a/src/main/webapp/WEB-INF/env-context.xml
+++ b/src/main/webapp/WEB-INF/env-context.xml
@@ -9,13 +9,8 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<bean id="applicationProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-		<property name="propertiesArray">
-			<list>
-				<bean class="org.cloudfoundry.identity.uaa.config.YamlPropertiesFactoryBean">
-					<property name="resources" value="classpath:/login.yml" />
-				</bean>
-				<bean class="org.cloudfoundry.identity.uaa.config.EnvironmentPropertiesFactoryBean" />
-			</list>
+		<property name="properties">
+			<bean class="org.cloudfoundry.identity.uaa.config.EnvironmentMapFactoryBean" />
 		</property>
 	</bean>
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -28,8 +28,12 @@
 			<param-value>org.cloudfoundry.identity.uaa.config.YamlServletProfileInitializer</param-value>
 		</init-param>
 		<init-param>
-			<param-name>CONFIG_FILE_NAME</param-name>
+			<param-name>environmentConfigDefaults</param-name>
 			<param-value>login.yml</param-value>
+		</init-param>
+		<init-param>
+			<param-name>environmentConfigLocations</param-name>
+			<param-value>${LOGIN_CONFIG_URL},file:${LOGIN_CONFIG_PATH}/login.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/login.yml</param-value>
 		</init-param>
 		<load-on-startup>1</load-on-startup>
 	</servlet>


### PR DESCRIPTION
The servlet initializer had some hardcoded references UAA_\* environment 
variable names.  This change removes those and makes them configurable via
the servlet context.

[#44222845] [cfid-598] remove small uaa.yml from war file
